### PR TITLE
Support binary variables

### DIFF
--- a/src/problem.lisp
+++ b/src/problem.lisp
@@ -76,6 +76,13 @@ inequalities and a list of integer variables."
       ((integer)
        (unioning (rest expr)
                  into integer))
+      ((binary)
+       (unioning (rest expr)
+                 into integer)
+       (appending (mapcar (lambda (var)
+			    (cons var '(0 . 1)))
+			  (rest expr))
+		  into bounds))
       ((bounds)
        (appending (mapcar (lambda (entry)
                             (cond


### PR DESCRIPTION
To extend the `integer` constraint, this patch would add a `binary` constraint, allowing all listed variables to either be 0 or 1.