### PR TITLE
use hash table instead of reduce union in parse-linear-problem

### DIFF
--- a/src/problem.lisp
+++ b/src/problem.lisp
@@ -6,7 +6,8 @@
          :linear-programming/expressions)
   (:import-from :alexandria
                 #:if-let
-                #:hash-table-keys)
+                #:hash-table-keys
+                #:hash-table-alist)
   (:import-from :linear-programming/utils
                 #:validate-bounds
                 #:lb-max
@@ -59,10 +60,21 @@
       (documentation 'problem-var-bounds 'function) "A list of variable bounds, of the form `(var . (lower-bound . upper-bound))`."
       (documentation 'problem-constraints 'function) "A list of (in)equality constraints.")
 
+(declaim (inline add-bound))
+(defun add-bound (bound-table var new-bound &optional implicit-lb)
+  (if-let (old-bound (gethash var bound-table))
+    (setf (gethash var bound-table)
+          (cons (lb-max (car old-bound) (car new-bound))
+                (ub-min (cdr old-bound) (cdr new-bound))))
+    (setf (gethash var bound-table)
+          (cons (or (car new-bound) implicit-lb)
+                (cdr new-bound)))))
+
 (defun parse-linear-constraints (exprs)
   "Parses the list of constraints and returns a list containing a list of simple
 inequalities and a list of integer variables."
   (iter expressions-loop
+        (with bound-table = (make-hash-table))
         (for expr in exprs)
     (case (first expr)
       ((<= <)
@@ -82,29 +94,26 @@ inequalities and a list of integer variables."
        (unioning (rest expr)
                  into integer))
       ((bounds)
-       (appending (mapcar (lambda (entry)
-                            (cond
-                              ((symbolp (first entry))
-                               (unless (and (<= (length entry) 2)
-                                            (or (null (second entry))
-                                                (numberp (second entry))))
-                                 (error 'parsing-error :description (format nil "Invalid bounds entry ~S" entry)))
-                               (cons (first entry) (cons nil (second entry))))
-                              (t
-                               (unless (and (numberp (first entry))
-                                            (symbolp (second entry))
-                                            (or (null (third entry))
-                                                (numberp (third entry))))
-                                 (error 'parsing-error :description (format nil "Invalid bounds entry ~S" entry)))
-                               (cons (second entry) (cons (first entry) (third entry))))))
-                          (rest expr))
-                  into bounds))
+       (dolist (entry (rest expr))
+         (cond
+           ((symbolp (first entry))
+            (unless (and (<= (length entry) 2)
+                         (or (null (second entry))
+                             (numberp (second entry))))
+              (error 'parsing-error :description (format nil "Invalid bounds entry ~S" entry)))
+            (add-bound bound-table (first entry) (cons nil (second entry))))
+           (t
+            (unless (and (numberp (first entry))
+                         (symbolp (second entry))
+                         (or (null (third entry))
+                             (numberp (third entry))))
+              (error 'parsing-error :description (format nil "Invalid bounds entry ~S" entry)))
+            (add-bound bound-table (second entry) (cons (first entry) (third entry)))))))
       ((binary)
        (unioning (rest expr)
                  into integer)
-       (appending (mapcar (lambda (var) `(,var . (0 . 1)))
-                          (rest expr))
-                  into bounds))
+       (dolist (var (rest expr))
+         (add-bound bound-table var '(0 . 1))))
       (t (error 'parsing-error :description (format nil "~A is not a valid constraint" expr))))
     (finally
       (iter equalities-loop
@@ -127,17 +136,9 @@ inequalities and a list of integer variables."
                         (new-bound (cond
                                      ((eq op '=) (cons const const))
                                      ((<= coef 0) (cons const nil))
-                                     (t (cons nil const))))
-                        (match (assoc var bounds))
-                        (old-bound (cdr match)))
-                   (if match
-                     (setf (cdr match)
-                           (cons (lb-max (car old-bound) (car new-bound))
-                                 (ub-min (cdr old-bound) (cdr new-bound))))
-                     (collect (cons var
-                                    (cons (or (car new-bound) 0) ; if there isn't a previous bound, use the implicit bound
-                                          (cdr new-bound)))
-                              into extra-bounds))))
+                                     (t (cons nil const)))))
+                   ;; if there isn't a previous bound, use the implicit bound
+                   (add-bound bound-table var new-bound 0)))
                 ((eq op '=)
                  (collect (list '= sum const) into simple-constraints))
                 ((<= 0 const)
@@ -146,19 +147,13 @@ inequalities and a list of integer variables."
                  (collect (list '>= (scale-linear-expression sum -1) (- const))
                           into simple-constraints))))))
         (finally
+         (maphash (lambda (var bound)
+                    (validate-bounds (car bound) (cdr bound) var))
+                  bound-table)
           (return-from expressions-loop
             (list simple-constraints
                   integer
-                  (reduce (lambda (result next)
-                            (if-let (match (assoc (first next) result))
-                              (let* ((lb (lb-max (car (cdr next)) (car (cdr match))))
-                                     (ub (ub-min (cdr (cdr next)) (cdr (cdr next)))))
-                                (validate-bounds lb ub (first next))
-                                (setf (cdr match) (cons lb ub))
-                                result)
-                              (list* next result)))
-                          (nconc extra-bounds bounds)
-                          :initial-value nil))))))))
+                  (hash-table-alist bound-table))))))))
 
 
 

--- a/src/problem.lisp
+++ b/src/problem.lisp
@@ -5,7 +5,8 @@
          :linear-programming/conditions
          :linear-programming/expressions)
   (:import-from :alexandria
-                #:if-let)
+                #:if-let
+                #:hash-table-keys)
   (:import-from :linear-programming/utils
                 #:validate-bounds
                 #:lb-max
@@ -187,24 +188,26 @@ inequalities and a list of integer variables."
            (integer-constraints (second parsed-constraints))
            (bounds (third parsed-constraints))
            ;collect all of the variables referenced
-           (var-list (remove-duplicates (mapcar #'car objective-func)))
-           (var-list (union var-list integer-constraints))
-           (var-list (union var-list (mapcar #'first bounds)))
-           (var-list (union var-list
-                            (reduce (lambda (l1 l2) (union l1 (mapcar #'car l2)))
-                                    eq-constraints
-                                    :key 'second
-                                    :initial-value nil)))
-           (variables (make-array (length var-list)
-                                  :initial-contents var-list
-                                  :element-type 'symbol)))
-      (make-problem :type type
-                    :vars variables
-                    :objective-var objective-var
-                    :objective-func objective-func
-                    :integer-vars integer-constraints
-                    :var-bounds bounds
-                    :constraints eq-constraints))))
+           (var-set (make-hash-table)))
+      (dolist (entry objective-func)
+        (setf (gethash (car entry) var-set) t))
+      (dolist (var integer-constraints)
+        (setf (gethash var var-set) t))
+      (dolist (bound bounds)
+        (setf (gethash (car bound) var-set) t))
+      (dolist (constraint eq-constraints)
+        (dolist (entry (second constraint))
+          (setf (gethash (car entry) var-set) t)))
+      (let ((variables (make-array (hash-table-count var-set)
+                                   :initial-contents (hash-table-keys var-set)
+                                   :element-type 'symbol)))
+        (make-problem :type type
+                      :vars variables
+                      :objective-var objective-var
+                      :objective-func objective-func
+                      :integer-vars integer-constraints
+                      :var-bounds bounds
+                      :constraints eq-constraints)))))
 
 
 (defmacro make-linear-problem (objective &rest constraints)


### PR DESCRIPTION
Turns out on larger problems, the union in the inner loop spend more time than calling the solver itself.

Using hash table makes this part run in a instant now :D

Feel free to ask for any stylish change for this to get merged! Really helps for larger problems.